### PR TITLE
Add arithmetic operations to vectors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,4 +4,4 @@ version = 3
 
 [[package]]
 name = "motion"
-version = "0.1.3"
+version = "0.1.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "motion"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 authors = ["Juanperias"]
 description = "A bare metal physics engine."

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,9 +21,9 @@
 //!
 //!    el.start(|_config| println!("Hello! in the event loop"), sleep);
 //!}
-//! // Extracted from: https://github.com/Juanperias/motion/blob/dev/examples/event_loop_example/src/main.rs
+//! https://github.com/Juanperias/motion/blob/main/examples/event_loop_example/src/main.rs
 //!```
-//! More examples in <https://github.com/Juanperias/motion/tree/dev/examples>
+//! More examples in <https://github.com/Juanperias/motion/tree/main/examples>
 //!
 
 #[cfg(feature = "vec")]

--- a/src/obj/obj_2d.rs
+++ b/src/obj/obj_2d.rs
@@ -127,14 +127,31 @@ pub fn obj2d<V: Into<Vec2d>>(
     )
 }
 
+/// `Object2dBuilder` is a structure used for building `Object2d` instances.
+///
+/// This builder pattern allows for a more readable and organized way to create `Object2d`
+/// objects by setting various fields in a fluid and chainable manner.
 #[derive(Debug)]
 pub struct Object2dBuilder {
+    /// The position vector of the object.
     position: Vec2d,
+
+    /// The density of the object.
     density: f32,
+
+    /// The mass of the object.
     mass: f32,
+
+    /// The velocity vector of the object.
     velocity: Vec2d,
+
+    /// The acceleration vector of the object.
     acceleration: Vec2d,
+
+    /// The radius of the object.
     radius: f32,
+
+    /// The shape of the object.
     shape: Shape,
 }
 

--- a/src/vec/vec_2d.rs
+++ b/src/vec/vec_2d.rs
@@ -1,4 +1,5 @@
 use crate::formulas::dot::length;
+use core::ops::{Add, Div, Mul, Sub};
 
 /// `Vec2d` is a simple 2D vector struct used for various vector operations.
 ///
@@ -80,6 +81,96 @@ impl Vec2d {
     pub fn distance(&self, target: Vec2d) -> f32 {
         let ab = self.component(target);
         length(ab)
+    }
+}
+
+/// Implements the addition of two 2D vectors.
+///
+/// This implementation allows using the `+` operator to add two `Vec2d` vectors component-wise.
+/// For example, `Vec2d { x: 1.0, y: 2.0 } + Vec2d { x: 3.0, y: 4.0 }` results in `Vec2d { x: 4.0, y: 6.0 }`.
+impl Add for Vec2d {
+    type Output = Vec2d;
+
+    /// Adds two `Vec2d` vectors.
+    ///
+    /// # Parameters
+    /// - `self`: The left-hand side vector in the addition.
+    /// - `rhs`: The right-hand side vector in the addition.
+    ///
+    /// # Returns
+    /// A new `Vec2d` vector where each component is the sum of the corresponding components of the input vectors.
+    fn add(self, rhs: Self) -> Self::Output {
+        Vec2d {
+            x: self.x + rhs.x,
+            y: self.y + rhs.y,
+        }
+    }
+}
+
+/// Implements the subtraction of two 2D vectors.
+///
+/// This implementation allows using the `-` operator to subtract one `Vec2d` vector from another component-wise.
+/// For example, `Vec2d { x: 5.0, y: 7.0 } - Vec2d { x: 3.0, y: 2.0 }` results in `Vec2d { x: 2.0, y: 5.0 }`.
+impl Sub for Vec2d {
+    type Output = Vec2d;
+
+    /// Subtracts one `Vec2d` vector from another.
+    ///
+    /// # Parameters
+    /// - `self`: The left-hand side vector in the subtraction.
+    /// - `rhs`: The right-hand side vector in the subtraction.
+    ///
+    /// # Returns
+    /// A new `Vec2d` vector where each component is the difference of the corresponding components of the input vectors.
+    fn sub(self, rhs: Self) -> Self::Output {
+        Vec2d {
+            x: self.x - rhs.x,
+            y: self.y - rhs.y,
+        }
+    }
+}
+
+/// Implements the dot product of two 2D vectors.
+///
+/// This implementation allows using the `*` operator to compute the dot product of two `Vec2d` vectors.
+/// The result is a scalar value representing the dot product.
+/// For example, `Vec2d { x: 1.0, y: 2.0 } * Vec2d { x: 3.0, y: 4.0 }` results in `11.0`.
+impl Mul for Vec2d {
+    type Output = f32;
+
+    /// Computes the dot product of two `Vec2d` vectors.
+    ///
+    /// # Parameters
+    /// - `self`: The left-hand side vector in the multiplication.
+    /// - `rhs`: The right-hand side vector in the multiplication.
+    ///
+    /// # Returns
+    /// A `f32` scalar value representing the dot product of the two input vectors.
+    fn mul(self, rhs: Self) -> Self::Output {
+        self.x * rhs.x + self.y * rhs.y
+    }
+}
+
+/// Implements scalar division for 2D vectors.
+///
+/// This implementation allows using the `/` operator to divide each component of a `Vec2d` vector by a scalar value of type `f32`.
+/// For example, `Vec2d { x: 10.0, y: 20.0 } / 2.0` results in `Vec2d { x: 5.0, y: 10.0 }`.
+impl Div<f32> for Vec2d {
+    type Output = Vec2d;
+
+    /// Divides each component of a `Vec2d` vector by a scalar value.
+    ///
+    /// # Parameters
+    /// - `self`: The vector to be divided.
+    /// - `rhs`: The scalar value to divide each component by.
+    ///
+    /// # Returns
+    /// A new `Vec2d` vector where each component is the result of the division of the corresponding component of the input vector by the scalar.
+    fn div(self, rhs: f32) -> Self::Output {
+        Vec2d {
+            x: self.x / rhs,
+            y: self.y / rhs,
+        }
     }
 }
 


### PR DESCRIPTION
This pull request add **basics operations to vectors** example:
```rust
use motion::vec::vec_2d::vec2;

fn main() {
    let vec = vec2(10.0, 10.0) + vec2(2.0, 2.0);

    assert_eq!(vec, vec2(12.0, 12.0))
}
```
And it also documents **Object2dBuilder**