### PR TITLE
Trigger workflow only on release creation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,31 +1,20 @@
 name: Release Crate
 
 on:
-  push:
-    paths-ignore:
-      - ".github/"
-      - "release.toml"
-      - "LICENSE"
-      - "README.md"
-      - "CONTRIBUTING.md"
-      - ".gitignore"
-    branches:
-      - main
+  release:
+    types: [created]
 
 jobs:
   release:
     runs-on: ubuntu-latest
-
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
-
       - name: Setup Rust
         uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
           override: true
-
       - name: Publish to crates.io
         uses: katyo/publish-crates@v2
         with:


### PR DESCRIPTION
This pull request changes the way in which the workflow release.toml is triggered so that it is for each release and not for each push to main.