### PR TITLE
Improve event loop

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,4 +4,4 @@ version = 3
 
 [[package]]
 name = "motion"
-version = "0.1.4"
+version = "0.1.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "motion"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2021"
 authors = ["Juanperias"]
 description = "A bare metal physics engine."

--- a/examples/event_loop_example/Cargo.lock
+++ b/examples/event_loop_example/Cargo.lock
@@ -11,6 +11,4 @@ dependencies = [
 
 [[package]]
 name = "motion"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01ad54e1f417c3110eb7f8cd6dd5b96e3c87136b7441b96fa7c796e30fcdb735"
+version = "0.1.4"

--- a/examples/event_loop_example/Cargo.toml
+++ b/examples/event_loop_example/Cargo.toml
@@ -4,4 +4,4 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-motion = "*"
+motion = { path = "*" }

--- a/examples/event_loop_example/src/main.rs
+++ b/examples/event_loop_example/src/main.rs
@@ -1,6 +1,6 @@
 use std::{thread, time::Duration};
 
-use motion::event_loop::{EventLoop, EventLoopConfig};
+use motion::event_loop::EventLoopBuilder;
 
 // The definition of this function depends on the context in which motion is used
 fn sleep(duration: Duration) {
@@ -8,7 +8,7 @@ fn sleep(duration: Duration) {
 }
 
 fn main() {
-    let el = EventLoop::new(EventLoopConfig { fps: 1 });
+    let el = EventLoopBuilder::new().fps(1).build();
 
     el.start(|_config| println!("Hello! in the event loop"), sleep);
 }

--- a/examples/raqote_example/Cargo.lock
+++ b/examples/raqote_example/Cargo.lock
@@ -303,8 +303,6 @@ dependencies = [
 [[package]]
 name = "motion"
 version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4d6a2daf29878349215175e013ded9ab4c0ff332b72865c8ed115b66416f16d"
 
 [[package]]
 name = "nix"

--- a/examples/raqote_example/Cargo.toml
+++ b/examples/raqote_example/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 minifb = { version = "0.27.0", features = ["wayland"] }
-motion = "0.1.4"
+motion = { path = "*" }
 # by default raqote asks for the fontconfig.pc lib installed but in this example it is not necessary.
 raqote = { version = "0.8.5", features = [
   "pathfinder_geometry",

--- a/src/event_loop/mod.rs
+++ b/src/event_loop/mod.rs
@@ -5,6 +5,8 @@ use core::time::Duration;
 pub struct EventLoopConfig {
     /// Frames per second for the event loop.
     pub fps: u32,
+    /// Delta time calculated from the fps.
+    pub delta_time: f32,
 }
 
 /// The main structure for the event loop, holding its configuration.
@@ -19,7 +21,7 @@ impl EventLoop {
     /// # Examples
     ///
     /// ```
-    /// let config = EventLoopConfig { fps: 60 };
+    /// let config = EventLoopConfig { fps: 60, delta_time: 1.0 / 60.0 };
     /// let event_loop = EventLoop::new(config);
     /// ```
     ///
@@ -40,7 +42,7 @@ impl EventLoop {
     /// # Examples
     ///
     /// ```
-    /// let config = EventLoopConfig { fps: 60 };
+    /// let config = EventLoopConfig { fps: 60, delta_time: 1.0 / 60.0 };
     /// let event_loop = EventLoop::new(config);
     ///
     /// event_loop.start(|config| {
@@ -64,6 +66,101 @@ impl EventLoop {
         loop {
             code(self.config);
             sleep(Duration::from_secs(u64::from(dt)));
+        }
+    }
+
+    /// Starts the event loop with a mutable closure, allowing modification of the loop configuration.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// let config = EventLoopConfig { fps: 60, delta_time: 1.0 / 60.0 };
+    /// let event_loop = EventLoop::new(config);
+    ///
+    /// event_loop.start_mut(|config| {
+    ///     // Your code here
+    /// }, |duration| {
+    ///     // Sleep for the duration
+    ///     std::thread::sleep(duration);
+    /// });
+    /// ```
+    ///
+    /// # Parameters
+    ///
+    /// - `code`: A mutable closure that takes `EventLoopConfig` and contains the code to run each frame.
+    /// - `sleep`: A closure that takes `Duration` and handles sleeping between frames.
+    pub fn start_mut<F, SF>(&self, mut code: F, sleep: SF)
+    where
+        F: FnMut(EventLoopConfig),
+        SF: Fn(Duration),
+    {
+        let dt = 1 / self.config.fps;
+        loop {
+            code(self.config);
+            sleep(Duration::from_secs(u64::from(dt)));
+        }
+    }
+}
+
+/// Builder pattern for constructing an `EventLoop`.
+#[derive(Debug)]
+pub struct EventLoopBuilder {
+    config: EventLoopConfig,
+}
+
+impl EventLoopBuilder {
+    /// Creates a new `EventLoopBuilder` with default configuration.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// let builder = EventLoopBuilder::new();
+    /// ```
+    pub fn new() -> Self {
+        EventLoopBuilder {
+            config: EventLoopConfig {
+                fps: 60,
+                delta_time: 1.0 / 60.0,
+            },
+        }
+    }
+
+    /// Sets the frames per second (fps) for the event loop.
+    ///
+    /// # Parameters
+    ///
+    /// - `fps`: The frames per second to set.
+    ///
+    /// # Returns
+    ///
+    /// The updated `EventLoopBuilder` instance.
+    pub fn fps(mut self, fps: u32) -> Self {
+        self.config = EventLoopConfig {
+            fps,
+            delta_time: 1.0 / fps as f32,
+        };
+        self
+    }
+
+    /// Builds the `EventLoop` with the specified configuration.
+    ///
+    /// # Returns
+    ///
+    /// A new `EventLoop` instance.
+    pub fn build(&self) -> EventLoop {
+        EventLoop {
+            config: self.config,
+        }
+    }
+}
+
+impl Default for EventLoopBuilder {
+    fn default() -> Self {
+        EventLoopBuilder {
+            config: EventLoopConfig {
+                fps: 60,
+                delta_time: 1.0 / 60.0,
+            },
         }
     }
 }


### PR DESCRIPTION
This pull request enhances the event loop by creating an EventLoopBuilder structure, example:
```rust
use std::{thread, time::Duration};

use motion::event_loop::EventLoopBuilder;

// The definition of this function depends on the context in which motion is used
fn sleep(duration: Duration) {
    thread::sleep(duration);
}

fn main() {
    let el = EventLoopBuilder::new().fps(1).build();

    el.start(|_config| println!("Hello! in the event loop"), sleep);
}
```